### PR TITLE
Fixes to make the library work with webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 
 exports = module.exports = require('./lib/ab-testing');
 
-exports.version = require('./package').version;
+exports.version = require('./package.json').version;

--- a/lib/ab-testing.js
+++ b/lib/ab-testing.js
@@ -3,8 +3,9 @@
  */
 
 var _ = require('underscore'),
-    md5 = require('blueimp-md5').md5;
+    blueImp = require('blueimp-md5');
 
+var md5 = blueImp.md5 || blueImp; // Forces this to work for webpack too: https://github.com/auth0/lock/pull/459/files
 
 /**
  * The config object contains a the information of the different tests, their names and weights.


### PR DESCRIPTION
Couple of issues prevent this module from working in a webpack (including Angular 6) project. Firstly, the `require('./package')` doesn't include JSON files by default; also, there's an issue with the blueimp library when bundling with webpack which is fixed in this PR.

Not sure if this library is still maintained but would be nice to see these fixes make their way to the published library on npm.