### PR TITLE
Fix nway tests

### DIFF
--- a/lib/ab-testing.js
+++ b/lib/ab-testing.js
@@ -104,7 +104,7 @@ var initTest = function (config) {
 
     tests.forEach(function (o) {
         o.weight += accumulativeWeight
-        accumulativeWeight += o.weight
+        accumulativeWeight = o.weight
     });
     return tests;
 };

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -27,6 +27,46 @@ describe('Init', function() {
 
         group.should.match(/^[A|B]/);
     });
+
+  it('should work with many groups', function() {
+    var users = [];
+    for (var i = 0; i <1000; i++) {
+      users.push(i);
+    }
+
+    var testObject = ABTesting.createTest('manyGroupTest', [{
+        name: 'A',
+        weight: 0.25
+      },
+      {
+        name: 'B',
+        weight: 0.25
+      },
+      {
+        name: 'C',
+        weight: 0.25
+      },
+      {
+        name: 'D',
+        weight: 0.25
+      }
+    ]);
+
+
+
+    var groups = users.reduce(function(accumulator, currentValue) {
+      cohort = testObject.getGroup(currentValue.toString());
+
+
+      accumulator[cohort] = true;
+
+
+      return accumulator;
+
+    }, {});
+
+    Object.keys(groups).sort().should.deep.equal(['A','B','C','D'])
+  });
 });
 
 describe('Test', function () {

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -84,7 +84,7 @@ describe('Test', function () {
                 }
             ]);
         } catch (err) {
-            err.should.exist();
+            err.should.exist;
         }
     });
     it('should return different groups for different users', function () {


### PR DESCRIPTION
We discovered that tests with more than three groups would completely disregard those groups. It looks like the `accumulativeWeight` was growing more quickly than intended.

Additionally, 3-way tests had the wrong distribution when set to equal weights (one test would end up with many more people than the other tests).

This PR adds a test to cover the "unused groups" condition and fixes a syntax issue in an existing test.