### PR TITLE
Fix safari sort bug

### DIFF
--- a/lib/ab-testing.js
+++ b/lib/ab-testing.js
@@ -99,7 +99,7 @@ var initTest = function (config) {
             }
         }
     }).sort(function (a, b) {
-        return a.weight > b.weight
+        return b.weight - a.weight
     });
 
     tests.forEach(function (o) {


### PR DESCRIPTION
# Description

- Safari is sorting differently than SSR (server side rendering) 
- Safari is sorting differently than chrome and other browsers

The main issue comes with SSR and Safari difference as it causes unexpected results.

SSR SORT ORDER
![image](https://user-images.githubusercontent.com/612095/72539422-4507d580-384d-11ea-9f4d-292880fe04de.png)

SAFARI SORT ORDER
![image](https://user-images.githubusercontent.com/612095/72539557-7a142800-384d-11ea-97a0-e31fd8c9da1e.png)

# The fix
Modify the sort to make Safari, SSR and all browsers consistent