### PR TITLE
Use build-in map instead of lodash.map

### DIFF
--- a/lib/ab-testing.js
+++ b/lib/ab-testing.js
@@ -3,7 +3,6 @@
  */
 
 var isFinite = require('lodash/isFinite'),
-    map = require('lodash/map'),
     blueImp = require('blueimp-md5');
 
 var md5 = blueImp.md5 || blueImp; // Forces this to work for webpack too: https://github.com/auth0/lock/pull/459/files
@@ -57,7 +56,9 @@ module.exports = {
             if(functions.length !== testData.length)
                 throw Error('The number of functions does not match the number of test groups');
 
-            var pluckedValues = map(testData, 'name');
+            var pluckedValues = testData.map(function (data) {
+                return data.name;
+            });
             var index = pluckedValues.indexOf(testGroupName);
 
             if(index === -1)
@@ -85,13 +86,13 @@ var initTest = function (config) {
         throw Error("Module not configured. Check your configuration.");
 
     // If no weight is provided, we give a static weight
-    var totalWeight = map(config, function (o) {
+    var totalWeight = config.map(function (o) {
         return isFinite(o.weight) ? o.weight : defaultWeight;
     }).reduce(function (a, b) {
         return a + b
     });
 
-    var tests = map(config, function (test) {
+    var tests = config.map(function (test) {
         if(test.name && typeof test.name === 'string') {
             return {
                 // Weight from 0..1

--- a/lib/ab-testing.js
+++ b/lib/ab-testing.js
@@ -2,7 +2,7 @@
  * Created by xavi on 14/12/14.
  */
 
-var isFinite = require('lodash/isFinite'),
+var isFinite = require('lodash.isfinite'),
     blueImp = require('blueimp-md5');
 
 var md5 = blueImp.md5 || blueImp; // Forces this to work for webpack too: https://github.com/auth0/lock/pull/459/files

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ab-testing",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -534,7 +534,13 @@
     "lodash": {
       "version": "4.17.20",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+      "dev": true
+    },
+    "lodash.isfinite": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+      "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
     },
     "log-symbols": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "blueimp-md5": "^1.1.0",
-    "lodash": "^4.17.20"
+    "lodash.isfinite": "^3.3.2"
   }
 }


### PR DESCRIPTION
## Description

- Remove `lodash/map` from dependences.
- Replace to modularized package (`lodash/isfinite` -> `lodash.isfinite`)
- reduce bundle size.